### PR TITLE
Allow attribute list interpolation

### DIFF
--- a/spec/generator-spec.js
+++ b/spec/generator-spec.js
@@ -72,4 +72,51 @@ describe('generator', () => {
     );
   });
 
+  it('uses an attribute', () => {
+      expectGenerated({
+        children: [
+          {
+      	    parent: {},
+      	    name: 'span',
+      	    attributes: [':attributes'],
+      	    children: []
+          }
+        ]
+      })
+      .toEqual(
+        'Html.span attributes []'
+      );
+  });
+
+  it('uses an attribute list', () => {
+    expectGenerated({
+      children: [
+        {
+      	  parent: {},
+      	  name: 'span',
+      	  attributes: [':attributes'],
+      	  children: []
+      	}
+      ]
+    })
+    .toEqual(
+      'Html.span attributes []'
+    );
+  });
+
+  it('uses an attribute and an attribute list', () => {
+    expectGenerated({
+      children: [
+        {
+          parent: {},
+          name: 'span',
+          attributes: ['Html.Attributes.attribute "id" "bar"',':attributes'],
+          children: []
+        }
+      ]
+    })
+    .toEqual(
+      'Html.span (List.concatMap identity [[Html.Attributes.attribute "id" "bar"], attributes]) []'
+    );
+  });
 });

--- a/spec/generator-spec.js
+++ b/spec/generator-spec.js
@@ -78,13 +78,13 @@ describe('generator', () => {
           {
       	    parent: {},
       	    name: 'span',
-      	    attributes: [':attributes'],
+      	    attributes: ['Html.Attributes.attribute "id" "foo"'],
       	    children: []
           }
         ]
       })
       .toEqual(
-        'Html.span attributes []'
+        'Html.span [Html.Attributes.attribute "id" "foo"] []'
       );
   });
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -51,6 +51,18 @@ function generateExpression(expr) {
   throw `Invalid expression: ${JSON.stringify(expr)}`
 }
 
+function generateAttributeList(simple,compound) {
+  const attributes = `[${simple.join(", ")}]`;
+  if (compound.length == 0) {
+    return attributes;
+  } else if (compound.length == 1 && simple.length == 0) {
+    return compound[0];
+  } else {
+    const all = `${attributes}, ${compound.join(", ")}`;
+    return `(List.concatMap identity [${all}])`;
+  }
+}
+
 function generate(state) {
   const { expr } = state;
   if (expr) return generateExpression(expr);
@@ -60,10 +72,10 @@ function generate(state) {
   }
 
   const name = state.name;
-  const attributes = state.attributes.join(", ");
+  const [compound,simple] = R.partition(x => x ? x.match(/^:.*/) : false, state.attributes);
+  const attributes = generateAttributeList(simple, compound.map(x => x.substr(1)));
   const children = parseChildren(state.children);
-
-  return `Html.${name} [${attributes}] ${children}`;
+  return `Html.${name} ${attributes} ${children}`;
 }
 
 generate.parseChildrenList = parseChildrenList;


### PR DESCRIPTION
An experiment to allow

    <input {:self.attributes} id={self.idstem} value={inputContent self}/>

to generate

    Html.input (List.concatMap identity [[Html.Attributes.attribute "id" self.idstem, Html.Attributes.attribute "value" (inputContent self)], self.attributes]) []

What do you think?